### PR TITLE
Move sitemap builder within check for site dir existence.

### DIFF
--- a/lib/ascii_binder/helpers.rb
+++ b/lib/ascii_binder/helpers.rb
@@ -663,7 +663,6 @@ module AsciiBinder
     def package_docs(package_site)
       site_map.each do |site,site_config|
         next if not package_site == '' and not package_site == site
-        puts "\nBuilding #{site} site."
         site_config[:distros].each do |distro,branches|
           branches.each do |branch,branch_config|
             src_dir  = File.join(preview_dir,distro,branch_config["dir"])
@@ -681,6 +680,8 @@ module AsciiBinder
           end
           site_dir = File.join(package_dir,site)
           if File.directory?(site_dir)
+            puts "\nBuilding #{site} site."
+
             # With this update, site index files will always come from the master branch
             working_branch_site_index = File.join(source_dir,'index-' + site + '.html')
             if File.exists?(working_branch_site_index)
@@ -691,14 +692,15 @@ module AsciiBinder
             else
               FileUtils.cp(File.join(preview_dir,distro,'index.html'),File.join(package_dir,site,'index.html'))
             end
-          end
-          # Now build a sitemap
-          site_dir_path = Pathname.new(site_dir)
-          SitemapGenerator::Sitemap.default_host = site_config[:url]
-          SitemapGenerator::Sitemap.create( :compress => false, :filename => File.join(site_dir,'sitemap') ) do
-            file_list = Find.find(site_dir).select{ |path| not path.nil? and path =~ /.*\.html$/ }.map{ |path| '/' + Pathname.new(path).relative_path_from(site_dir_path).to_s }
-            file_list.each do |file|
-              add(file, :changefreq => 'daily')
+
+            # Now build a sitemap
+            site_dir_path = Pathname.new(site_dir)
+            SitemapGenerator::Sitemap.default_host = site_config[:url]
+            SitemapGenerator::Sitemap.create( :compress => false, :filename => File.join(site_dir,'sitemap') ) do
+              file_list = Find.find(site_dir).select{ |path| not path.nil? and path =~ /.*\.html$/ }.map{ |path| '/' + Pathname.new(path).relative_path_from(site_dir_path).to_s }
+              file_list.each do |file|
+                add(file, :changefreq => 'daily')
+              end
             end
           end
         end

--- a/lib/ascii_binder/version.rb
+++ b/lib/ascii_binder/version.rb
@@ -1,3 +1,3 @@
 module AsciiBinder
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
Found this bug while migrating Jenkins hosts. Moves some logic inside the test for the `side_dir` directory so that the bug goes away, and some output messages make more sense.