### PR TITLE
Create 'asciibinder' utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.o
 *.a
 mkmf.log
+*.gem
+*.swp

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,3 @@
+require 'ascii_binder'
+gem_dir = Gem::Specification.find_by_name("ascii_binder").lib_dirs_glob
+instance_eval(File.read(File.join(gem_dir, 'ascii_binder/tasks/guards.rb')))

--- a/ascii_binder.gemspec
+++ b/ascii_binder.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json'
   spec.add_dependency 'pandoc-ruby'
   spec.add_dependency 'sitemap_generator', '~> 5.1.0'
+  spec.add_dependency 'trollop', '~> 2.1.2'
   spec.add_dependency 'yajl-ruby'
   spec.add_dependency 'tilt'
 end

--- a/bin/asciibinder
+++ b/bin/asciibinder
@@ -1,0 +1,155 @@
+#!/usr/bin/env ruby
+
+require 'ascii_binder/helpers'
+require 'pathname'
+require 'trollop'
+
+
+include AsciiBinder::Helpers
+
+SUB_COMMANDS = %w{help build watch package clean}
+Trollop::options do
+  banner <<-EOF
+Usage:
+  #$0 <command> <repo_dir>
+
+Commands:
+  build (default action)
+    Builds the HTML docs in the indicated repo dir
+  watch
+    Starts Guard, which automatically regenerates changed HTML
+    files on the working branch in the repo dir
+  package
+    Builds and packages the static HTML for all of the sites
+    defined in the _distro_config.yml file
+  clean
+    Remove _preview, _publish and _package dirs created by
+    other asciibinder operations.
+
+Options:
+EOF
+  stop_on SUB_COMMANDS
+end
+
+cmd = ARGV.shift
+repo_dir = nil
+
+if cmd.nil?
+  cmd = "build"
+elsif not SUB_COMMANDS.include?(cmd)
+  if not ARGV.empty?
+    Trollop::die "'#{cmd}' is not a valid asciibinder command. Legal values are '#{SUB_COMMANDS.join('\', \'')}'."
+  else
+    repo_dir = Pathname.new(cmd)
+    cmd = "build"
+  end
+end
+
+cmd_opts = case cmd
+  when "build"
+    Trollop::options do
+      banner <<-EOF
+Usage:
+  #$0 build <options> <repo_dir>
+
+Description:
+  This is the default behavior for the asciibinder utility. When run,
+  asciibinder reads the _distro_config.yml file out of the working
+  branch of the indicated repo directory and based on that, proceeds to
+  build the working branch version of the documentation for each distro.
+
+  Once the working branch version is built, asciibinder cycles through
+  the other branches named in the _distro_config.yml file until all of
+  the permutations have been built.
+
+Options:
+EOF
+      opt :distro, "Instead of building all distros, build branches only for the specified distro.", :default => ''
+    end
+  #when "new"
+  #  Trollop::options do
+  #    opt :initialize, "Create a new AsciiBinder-ready git repo in the target directory.", :default => true
+  #  end
+  when "watch"
+    Trollop::options do
+      banner <<-EOF
+Usage:
+  #$0 watch <repo_dir>
+
+Description:
+  In watch mode, asciibinder starts a Guard process in the foreground.
+  This process watches the repo_dir for changes to the AsciiDoc (.adoc)
+  files. When a change occurs, asciibinder regenerates the specific
+  HTML output of the file that was changed, for the working branch only.
+
+  This is meant to be used in conjunction with a web browser that is
+  running a LiveReload plugin. If you are viewing the output HTML page
+  in a browser where LiveReload is active, then every time you save a
+  new version of the .adoc file, the new HTML is automatically
+  regenrated and your page view is automatically refreshed.
+EOF
+    end
+  when "package"
+    Trollop::options do
+      banner <<-EOF
+Usage:
+  #$0 package <options> <repo_dir>
+
+Description:
+  Publish mode is similar to 'build' mode, but once all of the branches' of
+  HTML are generated, 'publish' goes on to organize the branch / distro
+  combinations that are described in _distro_config.yml into their "site"
+  layouts. As a final step, the site layouts are tarred and gzipped for
+  easy placement onto a production web server.
+
+Options:
+EOF
+      opt :site, "Instead of packaging every docs site, package the specified site only.", :default => ''
+    end
+  when "help"
+    Trollop::educate
+  end
+
+if (not repo_dir.nil? and not ARGV.empty?) or (repo_dir.nil? and ARGV.length > 1)
+  Trollop::die "Too many arguments provided to ascii_binder: '#{ARGV.join(' ')}'. Exiting."
+elsif repo_dir.nil?
+  if ARGV.length == 1
+    repo_dir = Pathname.new(ARGV.shift)
+  else
+    repo_dir = Pathname.pwd
+  end
+end
+
+# Validate the repo_dir path
+if not repo_dir.exist?
+  Trollop::die "The specified repo directory '#{repo_dir}' does not exist."
+elsif not repo_dir.directory?
+  Trollop::die "The specified repo directory path '#{repo_dir}' is not a directory."
+elsif not repo_dir.readable?
+  Trollop::die "The specified repo directory '#{repo_dir}' is not readable."
+elsif not repo_dir.writable?
+  Trollop::die "The specified repo directory '#{repo_dir}' cannot be written to."
+end
+
+# Set the repo root
+set_source_dir(File.expand_path(repo_dir))
+
+# Do the things with the stuff
+case cmd
+when "build"
+  build_distro = cmd_opts[:build] || ''
+  generate_docs(build_distro)
+when "package"
+  clean_up
+  generate_docs('')
+  package_site = cmd_opts[:site] || ''
+  package_docs(package_site)
+when "watch"
+  guardfile_path = File.join(Gem::Specification.find_by_name("ascii_binder").full_gem_path, 'Guardfile')
+  exec("guard -G #{guardfile_path}")
+when "clean"
+  clean_up
+  puts "Cleaned up #{repo_dir}."
+end
+
+exit

--- a/lib/ascii_binder/version.rb
+++ b/lib/ascii_binder/version.rb
@@ -1,3 +1,3 @@
 module AsciiBinder
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
This PR creates a utility that can be used to run the AsciiBinder system. It also enables users to run the utility from anywhere relative to the actual docs repo that they are processing. Finally, it fixes an issue where ditaa-generated images got tangled up in git stashes, leading to problems during builds.