### PR TITLE
Allow multiple stylesheets in template

### DIFF
--- a/templates/_templates/_css.html.erb
+++ b/templates/_templates/_css.html.erb
@@ -1,3 +1,3 @@
-<%- css.each do |sheet| -%>
-  <link href="<%= File.join(css_path, sheet) %>" rel="stylesheet" />
+<%- Dir.glob("_stylesheets/*").sort.each do |sheet| -%>
+  <link href="<%= File.join(css_path, File.basename(sheet)) %>" rel="stylesheet" />
 <%- end -%>

--- a/templates/_templates/page.html.erb
+++ b/templates/_templates/page.html.erb
@@ -9,7 +9,8 @@
   <!-- Bootstrap -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css">
-  <link href="<%= File.join(css_path, "asciibinder.css") %>" rel="stylesheet">
+
+  <%= render("_templates/_css.html.erb", :css_path => css_path) %>
 
    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
The templates that get deployed did not have support for multiple stylesheets.  This PR allows it to build the css URLs, so the user just has to create new stylesheets and drop them in.