### PR TITLE
Move header styling into asciibinder.css and clean up

### DIFF
--- a/templates/_stylesheets/asciibinder.css
+++ b/templates/_stylesheets/asciibinder.css
@@ -79,6 +79,11 @@ License: https://creativecommons.org/licenses/by/2.0/
   font-size: 28px;
 }
 
+.navbar-brand {
+  padding: initial;
+  height: initial;
+}
+
 .nav > li  > a.hover{
   background-color: none;
 }

--- a/templates/_templates/page.html.erb
+++ b/templates/_templates/page.html.erb
@@ -21,11 +21,6 @@
   <link href="<%= File.join(images_path, "favicon32x32.png") %>" rel="shortcut icon" type="text/css">
   <!--[if IE]><link rel="shortcut icon" href="<%= File.join(images_path, "favicon.ico") %>"><![endif]-->
   <meta content="AsciiBinder" name="application-name">
-  <style type="text/css">
-    .navbar-brand {
-      padding-top: 5px;
-    }
-  </style>
 </head>
 <body>
   <div class="navbar navbar-default" role="navigation">


### PR DESCRIPTION
@nhr Please review.

This allows images of different sizes to play nice in the header when replaced.