### PR TITLE
Add basic README and LICENSE to  template

### DIFF
--- a/templates/LICENSE.adoc
+++ b/templates/LICENSE.adoc
@@ -1,0 +1,10 @@
+= The MIT License (MIT)
+The MIT License (MIT)
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/templates/README.adoc
+++ b/templates/README.adoc
@@ -1,0 +1,2 @@
+= AsciiBinder-Based Docs Repo
+This docs repository was created with http://asciibinder.org/[AsciiBinder]. For more information on how AsciiBinder works, check out the http://asciibinder.org/latest/[documentation].


### PR DESCRIPTION
This PR addresses https://github.com/redhataccess/ascii_binder/issues/10

I used the MIT license because that is the same license we are using to distribute AsciiBinder. Docs maintainers, of course, cn change it to whichever license they want to use.