### PR TITLE
Fix expansion logic issue for 'all' case

### DIFF
--- a/lib/ascii_binder/helpers.rb
+++ b/lib/ascii_binder/helpers.rb
@@ -298,9 +298,11 @@ module AsciiBinder
 
     def parse_distros distros_string, for_validation=false
       values   = distros_string.split(',').map(&:strip)
+      # Don't bother with glob expansion if 'all' is in the list.
+      return distro_map.keys if values.include?('all')
+
       expanded = expand_distro_globs(values)
       return expanded if for_validation
-      return distro_map.keys if expanded.include?('all')
       return expanded.uniq
     end
 


### PR DESCRIPTION
@Fryguy found a bug for `_build_cfg.yml` entries that don't include a Distro: property. The 'all' value that we include wasn't surviving expansion, which left an empty list. In the presence of the 'all' value the expansion logic isn't necessary, so I've modified the expansion code to account for this.