### PR TITLE
Remove in-doc ifdef::[] glob preprocessing

### DIFF
--- a/lib/ascii_binder/helpers.rb
+++ b/lib/ascii_binder/helpers.rb
@@ -728,13 +728,6 @@ module AsciiBinder
     if file_lines.length > 0
       article_title  = file_lines[0].gsub(/^\=\s+/, '').gsub(/\s+$/, '').gsub(/\{product-title\}/, distro_config["name"]).gsub(/\{product-version\}/, branch_config["name"])
     end
-
-    # Scan the file for ifdefs and perform any distro key glob expansions
-    file_lines.each do |line|
-      # This non-greedy match will only capture the first ifdef::<key_list>[] construction on a given line,
-      # but AsciiDoc only supports one per line.
-      line.sub!(IFDEF_STRING_RE) { |m| "ifdef::#{expand_distro_globs($1.split(',')).join(',')}[]" }
-    end
     topic_adoc = file_lines.join("\n")
 
     topic_html = Asciidoctor.render topic_adoc, :header_footer => false, :safe => :unsafe, :attributes => page_attrs

--- a/lib/ascii_binder/version.rb
+++ b/lib/ascii_binder/version.rb
@@ -1,3 +1,3 @@
 module AsciiBinder
-  VERSION = "0.1.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
@Fryguy After discussing this with the customer portal tools team, I've agreed to back off of glob support in ifdef::[] statements, as they are not supported by the AsciiDoc spec. Glob support will still exist for `_build_cfg.yml`, where it is most useful.