### PR TITLE
Avoid rescuing Exception.

### DIFF
--- a/bin/asciibinder
+++ b/bin/asciibinder
@@ -13,8 +13,9 @@ def call_generate(branch_group, distro, page)
   end
   begin
     generate_docs(branch_group, distro, page)
-  rescue Exception => e
-    Trollop::die "Could not generate docs: #{e.message}"
+  rescue => e
+    message = "#{e.class.name}: #{e.message} at\n    #{e.backtrace.join("\n    ")}"
+    Trollop::die "Could not generate docs:\n#{message}"
   end
 end
 

--- a/lib/ascii_binder/helpers.rb
+++ b/lib/ascii_binder/helpers.rb
@@ -153,11 +153,7 @@ module AsciiBinder
       gem_template_dir = File.join(gem_root_dir,"templates")
 
       # Create the new repo dir
-      begin
-        Dir.mkdir(source_dir)
-      rescue Exception => e
-        raise "Could not create directory '#{source_dir}': #{e.message}"
-      end
+      FileUtils.mkdir_p(source_dir)
 
       # Copy the basic repo content into the new repo dir
       Find.find(gem_template_dir).each do |path|
@@ -171,13 +167,8 @@ module AsciiBinder
         end
       end
 
-      # Initialize the git repo and check everything in
-      g = nil
-      begin
-        g = Git.init(source_dir)
-      rescue Exception => e
-        raise "Could not initialize git repo in '#{source_dir}': #{e.message}"
-      end
+      # Initialize the git repo
+      Git.init(source_dir)
     end
 
     def find_topic_files


### PR DESCRIPTION
@nhr Please review.

The change to printing the backtrace in call_generate is what helped my find the problem that @aweiteka ran into in the openshift-docs.

I noticed the rescuing of Exception anyway though, which is a general no-no, so I removed them all.  The other two removals will still raise a very clear error message, so nothing is lost.