### PR TITLE
Add Site URL and topic path to available template variables.

### DIFF
--- a/lib/ascii_binder/helpers.rb
+++ b/lib/ascii_binder/helpers.rb
@@ -736,46 +736,48 @@ module AsciiBinder
         "product-author=#{distro_config["author"]}"
       ])
 
-    # Because we render only the body of the article with AsciiDoctor, the full article title
-    # would be lost in conversion. So, use the _build_cfg.yml 'Name' as a fallback but try
-    # to read the full article title out of the file itself.
-    file_lines    = topic_adoc.split("\n")
-    article_title = topic['Name']
-    if file_lines.length > 0
-      article_title  = file_lines[0].gsub(/^\=\s+/, '').gsub(/\s+$/, '').gsub(/\{product-title\}/, distro_config["name"]).gsub(/\{product-version\}/, branch_config["name"])
-    end
-    topic_adoc = file_lines.join("\n")
+      # Because we render only the body of the article with AsciiDoctor, the full article title
+      # would be lost in conversion. So, use the _build_cfg.yml 'Name' as a fallback but try
+      # to read the full article title out of the file itself.
+      file_lines    = topic_adoc.split("\n")
+      article_title = topic['Name']
+      if file_lines.length > 0
+        article_title  = file_lines[0].gsub(/^\=\s+/, '').gsub(/\s+$/, '').gsub(/\{product-title\}/, distro_config["name"]).gsub(/\{product-version\}/, branch_config["name"])
+      end
+      topic_adoc = file_lines.join("\n")
 
-    topic_html = Asciidoctor.render topic_adoc, :header_footer => false, :safe => :unsafe, :attributes => page_attrs
-    dir_depth  = ''
-    if branch_config['dir'].split('/').length > 1
-      dir_depth = '../' * (branch_config['dir'].split('/').length - 1)
-    end
-    if not topic_subgroup.nil?
-      dir_depth = '../' + dir_depth
-    end
-    page_args = {
-      :distro_key       => distro,
-      :distro           => distro_config["name"],
-      :site_name        => site_name,
-      :version          => branch_config["name"],
-      :group_title      => topic_group['Name'],
-      :subgroup_title   => topic_subgroup && topic_subgroup['Name'],
-      :topic_title      => topic['Name'],
-      :article_title    => article_title,
-      :content          => topic_html,
-      :navigation       => navigation,
-      :group_id         => topic_group['ID'],
-      :subgroup_id      => topic_subgroup && topic_subgroup['ID'],
-      :topic_id         => topic['ID'],
-      :css_path         => "../../#{dir_depth}#{branch_config["dir"]}/#{STYLESHEET_DIRNAME}/",
-      :javascripts_path => "../../#{dir_depth}#{branch_config["dir"]}/#{JAVASCRIPT_DIRNAME}/",
-      :images_path      => "../../#{dir_depth}#{branch_config["dir"]}/#{IMAGE_DIRNAME}/",
-      :site_home_path   => "../../#{dir_depth}index.html",
-      :template_path    => template_dir,
-    }
-    full_file_text = page(page_args)
-    File.write(tgt_file_path,full_file_text)
+      topic_html = Asciidoctor.render topic_adoc, :header_footer => false, :safe => :unsafe, :attributes => page_attrs
+      dir_depth  = ''
+      if branch_config['dir'].split('/').length > 1
+        dir_depth = '../' * (branch_config['dir'].split('/').length - 1)
+      end
+      if not topic_subgroup.nil?
+        dir_depth = '../' + dir_depth
+      end
+      page_args = {
+        :distro_key       => distro,
+        :distro           => distro_config["name"],
+        :site_name        => site_name,
+        :site_url         => distro_config["site_url"],
+        :topic_url        => "#{branch_config['dir']}/#{topic_path}.html",
+        :version          => branch_config["name"],
+        :group_title      => topic_group['Name'],
+        :subgroup_title   => topic_subgroup && topic_subgroup['Name'],
+        :topic_title      => topic['Name'],
+        :article_title    => article_title,
+        :content          => topic_html,
+        :navigation       => navigation,
+        :group_id         => topic_group['ID'],
+        :subgroup_id      => topic_subgroup && topic_subgroup['ID'],
+        :topic_id         => topic['ID'],
+        :css_path         => "../../#{dir_depth}#{branch_config["dir"]}/#{STYLESHEET_DIRNAME}/",
+        :javascripts_path => "../../#{dir_depth}#{branch_config["dir"]}/#{JAVASCRIPT_DIRNAME}/",
+        :images_path      => "../../#{dir_depth}#{branch_config["dir"]}/#{IMAGE_DIRNAME}/",
+        :site_home_path   => "../../#{dir_depth}index.html",
+        :template_path    => template_dir,
+      }
+      full_file_text = page(page_args)
+      File.write(tgt_file_path,full_file_text)
     end
 
     # package_docs


### PR DESCRIPTION
This addresses issue https://github.com/redhataccess/ascii_binder/issues/26 by exposing `site_url` and `topic_url` variables for use in page templates.

Note that because the `site_url` value is already expected to have a trailing '/', a correct concatenation of these values into a complete URL would look like this in a template:

    <link rel="canonical" "<%= "#{site_url}#{topic_url}" %>">

@Fryguy plz review. 