### PR TITLE
Explicitly install SCL-compatibile 'listen' gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos/ruby-22-centos7
 
+RUN scl enable rh-ruby22 -- gem install listen -v 3.0.8
 RUN scl enable rh-ruby22 -- gem install ascii_binder
 USER root
 RUN yum install -y java-1.7.0-openjdk && \


### PR DESCRIPTION
This addresses Docker image build issues raised in https://github.com/redhataccess/ascii_binder/issues/46