### PR TITLE
Improve call to sitemap generator

### DIFF
--- a/lib/ascii_binder/helpers.rb
+++ b/lib/ascii_binder/helpers.rb
@@ -837,8 +837,12 @@ module AsciiBinder
 
             # Now build a sitemap
             site_dir_path = Pathname.new(site_dir)
-            SitemapGenerator::Sitemap.default_host = site_config[:url]
-            SitemapGenerator::Sitemap.create( :compress => false, :filename => File.join(site_dir,'sitemap') ) do
+            SitemapGenerator::Sitemap.create(
+              :default_host => site_config[:url],
+              :public_path  => site_dir_path,
+              :compress     => false,
+              :filename     => File.join(site_dir,'sitemap')
+            ) do
               file_list = Find.find(site_dir).select{ |path| not path.nil? and path =~ /.*\.html$/ }.map{ |path| '/' + Pathname.new(path).relative_path_from(site_dir_path).to_s }
               file_list.each do |file|
                 add(file, :changefreq => 'daily')


### PR DESCRIPTION
Clean up invocation and add `public_path` argument to prevent the creation of a folder called 'public' in the doc repo root dir.