### PR TITLE
Expand 'site file' logic to work more broadly

### DIFF
--- a/lib/ascii_binder/version.rb
+++ b/lib/ascii_binder/version.rb
@@ -1,3 +1,3 @@
 module AsciiBinder
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
Any files in the root of the docs repo with names ending in:

    *-SITE.html

(where SITE is a distro map site key value) will get copied into the root dir of the packaged site with the site name stripped out.

Example: for site name 'commercial', the files:
* index-commercial.html would end up as #{site_root}/index.html
* search-commercial.html would end up as #{site_root}/search.html
* index-community.html would be ignored