### PR TITLE
Prevent erroneous repeat branch builds

### DIFF
--- a/bin/asciibinder
+++ b/bin/asciibinder
@@ -291,8 +291,9 @@ when "build"
   call_generate(branch_group,build_distro,refresh_page)
 when "package"
   clean_up
-  call_generate(:publish,'',nil)
   package_site = cmd_opts[:site] || ''
+  branch_group = package_site == '' ? :publish : "publish_#{package_site}".to_sym
+  call_generate(branch_group,'',nil)
   package_docs(package_site)
 when "watch"
   if !dir_empty?(preview_dir)

--- a/lib/ascii_binder/version.rb
+++ b/lib/ascii_binder/version.rb
@@ -1,3 +1,3 @@
 module AsciiBinder
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
Line 257 of `lib/ascii_binder/helpers.rb` was creating a branch list where the same branch could occur more than once. In practice, this was causing some _very strange_ behavior including the intermingling of branch content at the site packaging stage.

Additionally, when `asciibinder package --site=foo` was invoked, AsciiBinder would still _build_ everything before selectively assembling the content only for the specified site "foo". So this PR also speeds up site publication by only processing branches needed by the specified site.

@Fryguy and @adellape please review.