### PR TITLE
Adding Kramdown support to process Markdown files

### DIFF
--- a/ascii_binder.gemspec
+++ b/ascii_binder.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'guard-livereload'
   spec.add_dependency 'haml'
   spec.add_dependency 'json'
+  spec.add_dependency 'kramdown'
   spec.add_dependency 'pandoc-ruby'
   spec.add_dependency 'sitemap_generator', '~> 5.1.0'
   spec.add_dependency 'trollop', '~> 2.1.2'

--- a/lib/ascii_binder/engine.rb
+++ b/lib/ascii_binder/engine.rb
@@ -10,6 +10,8 @@ require 'asciidoctor-diagram'
 require 'fileutils'
 require 'find'
 require 'git'
+require 'kramdown'
+require 'logger'
 require 'pandoc-ruby'
 require 'pathname'
 require 'sitemap_generator'
@@ -127,9 +129,9 @@ module AsciiBinder
     def find_topic_files
       file_list = []
       Find.find(docs_root_dir).each do |path|
-        # Only consider .adoc files and ignore README, and anything in
+        # Only consider .adoc and .md files and ignore README, and anything in
         # directories whose names begin with 'old' or '_' (underscore)
-        next if path.nil? or not path =~ /.*\.adoc/ or path =~ /README/ or path =~ /\/old\// or path =~ /\/_/
+        next if path.nil? or not (path =~ /.*\.adoc/ or path =~ /.*\.md/) or path =~ /README/ or path =~ /\/old\// or path =~ /\/_/
         src_path = Pathname.new(path).sub(docs_root_dir,'').to_s
         next if src_path.split('/').length < 3
         file_list << src_path
@@ -315,7 +317,7 @@ module AsciiBinder
         end
 
         # The branch_orphan_files list starts with the set of all
-        # .adoc files found in the repo, and will be whittled
+        # topic files found in the repo, and will be whittled
         # down from there.
         branch_orphan_files = find_topic_files
         branch_topic_map    = topic_map
@@ -452,7 +454,7 @@ module AsciiBinder
 
     def configure_and_generate_page(topic,branch_config,navigation)
       distro = branch_config.distro
-      topic_adoc = File.open(topic.source_path,'r').read
+      topic_content = File.open(topic.source_path,'r').read
 
       page_attrs = asciidoctor_page_attrs([
         "imagesdir=#{File.join(topic.parent.source_path,'images')}",
@@ -463,10 +465,15 @@ module AsciiBinder
         "repo_path=#{topic.repo_path}"
       ])
 
-      doc = without_warnings { Asciidoctor.load topic_adoc, :header_footer => false, :safe => :unsafe, :attributes => page_attrs }
-      article_title = doc.doctitle || topic.name
+      if File.extname(topic.source_path) == '.md'
+        topic_html = without_warnings { Kramdown::Document.new(topic_content).to_html } # add back options see below
+        article_title = "" # There is no article title pass into markdown templates
+      else
+        doc = without_warnings { Asciidoctor.load topic_content, :header_footer => false, :safe => :unsafe, :attributes => page_attrs }
+        article_title = doc.doctitle || topic.name
+        topic_html = doc.render
+      end
 
-      topic_html = doc.render
       dir_depth  = ''
       if branch_config.dir.split('/').length > 1
         dir_depth = '../' * (branch_config.dir.split('/').length - 1)
@@ -537,6 +544,14 @@ module AsciiBinder
             next if not File.directory?(src_dir)
             FileUtils.mkdir_p(tgt_dir)
             FileUtils.cp_r(src_dir,tgt_dir)
+            # Copy over image directories - needed for non adoc/data-uri formats
+            topic_map.dirpaths.each do |group_dir|
+              image_dir = File.join(docs_root_dir,group_dir, "images")
+              image_dir_tgt = File.join(package_dir,site.id,branch.dir,group_dir)
+              if File.directory?(image_dir)
+                FileUtils.cp_r(image_dir,image_dir_tgt)
+              end
+            end
           end
           site_dir = File.join(package_dir,site.id)
           if File.directory?(site_dir)

--- a/lib/ascii_binder/tasks/guards.rb
+++ b/lib/ascii_binder/tasks/guards.rb
@@ -1,5 +1,5 @@
 guard 'shell' do
-  watch(/^.*\.adoc$/) { |m|
+  watch(/^.*\.(adoc|md)$/) { |m|
     if not m[0].start_with?('_preview') and not m[0].start_with?('_package')
       full_path      = m[0].split('/')
       src_group_path = full_path.length == 1 ? '' : full_path[0..-2].join('/')

--- a/lib/ascii_binder/topic_entity.rb
+++ b/lib/ascii_binder/topic_entity.rb
@@ -37,7 +37,11 @@ module AsciiBinder
         if is_group?
           this_step = dir
         elsif is_topic?
-          this_step = file.end_with?('.adoc') ? file : "#{file}.adoc"
+          if File.extname(file) == '.adoc' or File.extname(file) == '.md'
+            this_step = file
+          else
+            this_step = "#{file}.adoc"
+          end
         end
         @dir_path == '' ? this_step : File.join(@dir_path,this_step)
       end
@@ -48,7 +52,15 @@ module AsciiBinder
     end
 
     def repo_path_html
-      @repo_path_html ||= is_topic? ? File.join(File.dirname(repo_path),File.basename(repo_path,'.adoc')) + ".html" : repo_path
+      if is_topic?
+        if File.extname(repo_path) == '.adoc'
+          @repo_path_html = File.join(File.dirname(repo_path),File.basename(repo_path, '.adoc')) + ".html"
+        else
+          @repo_path_html = File.join(File.dirname(repo_path),File.basename(repo_path, '.md')) + ".html"
+        end
+      else
+        @repo_path_html = repo_path
+      end
     end
 
     def source_path
@@ -75,6 +87,22 @@ module AsciiBinder
           group_filepaths.uniq!
         end
         group_filepaths
+      end
+    end
+
+    def group_dirpaths
+      @group_dirpaths ||= begin
+        group_dirpaths = []
+        if is_group?
+          #group_dirpaths << File.join(File.dirname(repo_path),File.basename(repo_path,'.adoc'))
+          group_dirpaths << repo_path
+        else
+          subitems.each do |subitem|
+            group_dirpaths.concat(subitem.group_filepaths)
+          end
+          group_dirpaths.uniq!
+        end
+        group_dirpaths
       end
     end
 

--- a/lib/ascii_binder/topic_map.rb
+++ b/lib/ascii_binder/topic_map.rb
@@ -18,6 +18,16 @@ module AsciiBinder
       end
     end
 
+    def dirpaths
+      @dirpaths ||= begin
+        dirpaths = []
+        @list.each do |topic_entity|
+          dirpaths.concat(topic_entity.group_dirpaths)
+        end
+        dirpaths
+      end
+    end
+
     def filepaths
       @filepaths ||= begin
         filepaths = []

--- a/templates/_templates/page.html.erb
+++ b/templates/_templates/page.html.erb
@@ -55,9 +55,11 @@
         <%= render("_templates/_nav.html.erb", :navigation => navigation, :group_id => group_id, :topic_id => topic_id, :subgroup_id => subgroup_id, :subtopic_shim => subtopic_shim) %>
       </div>
       <div class="col-xs-12 col-sm-9 col-md-9 main">
-        <div class="page-header">
-          <h2><%= article_title %></h2>
-        </div>
+        <% if article_title != "" %>
+          <div class="page-header">
+            <h2><%= article_title %></h2>
+          </div>
+        <% end %>
         <%= content %>
       </div>
     </div>

--- a/templates/_topic_map.yml
+++ b/templates/_topic_map.yml
@@ -25,5 +25,6 @@ Name: AsciiBinder Doc Project
 Dir: welcome
 Topics:
   - Name: Welcome
-    File: index
-
+    File: index.adoc
+  - Name: Markdown Information
+    File: markdown.md

--- a/templates/welcome/index.adoc
+++ b/templates/welcome/index.adoc
@@ -6,6 +6,8 @@
 
 Welcome to the AsciiBinder Docs Management System. This welcome page is provided as a template for the topic pages that you will create for your software project.
 
+AsciiBinder can process both AsciiDoc and link:markdown.html[Markdown] files in the same repository
+
 == Need Help?
 * Check out the http://www.asciibinder.org/latest/welcome/[AsciiBinder documentation]
 * Join our http://groups.google.com/group/asciibinder[mailing list]

--- a/templates/welcome/markdown.md
+++ b/templates/welcome/markdown.md
@@ -1,0 +1,12 @@
+# Documentation
+
+Welcome to the AsciiBinder Docs Management System. This welcome page is provided as a template for the topic pages that you will create for your software project.
+
+AsciiBinder can process both [AsciiDoc](index.html) and Markdown files in the same repository
+
+## Need Help?
+
+* Check out the [AsciiBinder documentation](http://www.asciibinder.org/latest/welcome/)
+* Join our [mailing list](http://groups.google.com/group/asciibinder)
+* Find us on IRC at FreeNode, [#asciibinder](http://webchat.freenode.net/?randomnick=1&channels=asciibinder&uio=d4) channel
+* Open an [issue on GitHub](https://github.com/redhataccess/ascii_binder/issues)


### PR DESCRIPTION
This is a proof of concept PR being submitted for feedback.  It is not intended
to be merged, yet.

Using the kramdown[0] processer rich Markdown format is supported for side by
side processing with existing AsciiDoc files.

[0]: https://kramdown.gettalong.org/

Known Bug: The images used in Markdown files are currently not copied to the
output directory.  This is because AsciiDoc is currently processed through
AsciiDoctor using the `data-uri` option.  There is no analogous option in
kramdown.  Two options being considered:

a) Get Kramdown to implment a data-uri like option.
b) Copy over image files as part of built sites in AsciiBinder when Markdown is
detected.  This could also result in a new option to allow custom override of
the data-uri option.

Known Bug: The additional options (other than data-uri) passed ot AsciiDoctor
have not been checked for analougous support in kramdown.

* 'source-highlighter=coderay'
* 'coderay-css=style'
* 'linkcss!'
* 'icons=font'
* 'idprefix='
* 'idseparator=-'
* 'sectanchors'
* 'data-uri' - see above

Specific changes/fixes:

ascii_binder.gemspec:
- add kramdown dependency

lib/ascii_binder/engine.rb:
- add kramdown requirement
- expand topic file definition to include both .adoc and .md files
- when deleting extensions, only remove .adoc - this preserves legacy support
  for _topic_map.yml entries with no file extension being assumed to be .adoc
  - See: https://github.com/redhataccess/ascii_binder/issues/104
  - This should probably be in a separate PR
  - This needs to have the commented lines delete
- modify output message to reference "topic files" not ".adoc files"
- rename topic_adoc variable that holds the topic file content to topic_content
- add kramdown processing for files ending in '.md'
  - Note: article_title is not supported (see template modifications below)

lib/ascii_binder/tasks/guards.rb:
- watch both .adoc and .md files
  - This is untested

lib/ascii_binder/topic_entity.rb:
- only append .adoc to files that have neither a .adoc or .md extension
  - See related issue: https://github.com/redhataccess/ascii_binder/issues/105
  - This may need to be split into two PRs, one to fix the issue and one for
    adding .md
- When determining the .html file path, remove either .adoc or .md as needed

templates/_templates/page.html.erb:
- Make display of page-header/article_title optional as it is not supported
  with Markdown

templates/_topic_map.yml:
templates/welcome/index.adoc:
templates/welcome/markdown.md:
- Add an example Markdown file and include links between the two files to the
  template