### PR TITLE
Remove leading / from branch_files

### DIFF
--- a/lib/ascii_binder/engine.rb
+++ b/lib/ascii_binder/engine.rb
@@ -134,7 +134,7 @@ module AsciiBinder
         next if src_path.split('/').length < 3
         file_list << src_path
       end
-      file_list.map{ |path| File.join(File.dirname(path),File.basename(path,'.adoc')) }
+      file_list.map{ |path| File.join(File.dirname(path),File.basename(path,'.adoc'))[1..-1] }
     end
 
     def remove_found_topic_files(branch,branch_topic_map,branch_topic_files)


### PR DESCRIPTION
The leading / causes the comparison to the topic map to fail