### PR TITLE
Add support for unlimited navigation templates

### DIFF
--- a/bin/asciibinder
+++ b/bin/asciibinder
@@ -133,6 +133,7 @@ EOF
       opt :distro, "Instead of building all distros, build branches only for the specified distro.", :default => ''
       opt :page, "Build only the specified page for all distros and only the current working branch.", :default => ''
       opt :log_level, "Set the logging output level for this operation.", :default => 'warn'
+      opt :toc_depth, "Maximum depth of topics allowed.  Use 0 for infinite depth.", :default => 2
       conflicts :distro, :page
     end
   when "create"
@@ -207,6 +208,7 @@ Options:
 EOF
       opt :site, "Instead of packaging every docs site, package the specified site only.", :default => ''
       opt :log_level, "Set the logging output level for this operation.", :default => 'warn'
+      opt :toc_depth, "Maximum depth of topics allowed.  Use 0 for infinite depth.", :default => 2
     end
   when "help"
     Trollop::educate
@@ -273,6 +275,13 @@ unless cmd_opts.nil? or cmd_opts[:log_level].nil?
   end
 end
 set_log_level(user_log_level)
+
+# Set the depth level
+user_depth = 2
+unless cmd_opts.nil? or cmd_opts[:toc_depth].nil?
+  user_depth = cmd_opts[:toc_depth].to_i
+end
+set_depth(user_depth)
 
 
 # Cloning? Time to try it.

--- a/lib/ascii_binder/engine.rb
+++ b/lib/ascii_binder/engine.rb
@@ -188,11 +188,12 @@ module AsciiBinder
       args[:breadcrumb_root], args[:breadcrumb_group], args[:breadcrumb_subgroup], args[:breadcrumb_topic] = extract_breadcrumbs(args)
 
       args[:breadcrumb_subgroup_block] = ''
-      args[:subtopic_shim]             = ''
       if args[:breadcrumb_subgroup]
         args[:breadcrumb_subgroup_block] = "<li class=\"hidden-xs active\">#{args[:breadcrumb_subgroup]}</li>"
-        args[:subtopic_shim]             = '../'
       end
+
+      args[:subtopic_shim] = '../' * (args[:topic_id].split('::').length - 2)
+      args[:subtopic_shim] = '' if args[:subtopic_shim].nil?
 
       template_path = File.expand_path("#{docs_root_dir}/_templates/page.html.erb")
       template_renderer.render(template_path, args)
@@ -466,10 +467,6 @@ module AsciiBinder
       article_title = doc.doctitle || topic.name
 
       topic_html = doc.render
-      dir_depth  = ''
-      if branch_config.dir.split('/').length > 1
-        dir_depth = '../' * (branch_config.dir.split('/').length - 1)
-      end
 
       # This is logic bridges newer arbitrary-depth-tolerant code to
       # older depth-limited code. Truly removing depth limitations will
@@ -484,8 +481,9 @@ module AsciiBinder
       if breadcrumb.length == 3
         subgroup_title = breadcrumb[1][:name]
         subgroup_id    = breadcrumb[1][:id]
-        dir_depth      = '../' + dir_depth
       end
+      dir_depth = '../' * topic.breadcrumb[-1][:id].split('::').length
+      dir_depth = '' if dir_depth.nil?
 
       preview_path = topic.preview_path(distro.id,branch_config.dir)
       topic_publish_url = topic.topic_publish_url(distro.site.url,branch_config.dir)
@@ -508,10 +506,10 @@ module AsciiBinder
         :group_id          => group_id,
         :subgroup_id       => subgroup_id,
         :topic_id          => topic_id,
-        :css_path          => "../../#{dir_depth}#{branch_config.dir}/#{STYLESHEET_DIRNAME}/",
-        :javascripts_path  => "../../#{dir_depth}#{branch_config.dir}/#{JAVASCRIPT_DIRNAME}/",
-        :images_path       => "../../#{dir_depth}#{branch_config.dir}/#{IMAGE_DIRNAME}/",
-        :site_home_path    => "../../#{dir_depth}index.html",
+        :css_path          => "#{dir_depth}#{branch_config.dir}/#{STYLESHEET_DIRNAME}/",
+        :javascripts_path  => "#{dir_depth}#{branch_config.dir}/#{JAVASCRIPT_DIRNAME}/",
+        :images_path       => "#{dir_depth}#{branch_config.dir}/#{IMAGE_DIRNAME}/",
+        :site_home_path    => "#{dir_depth}index.html",
         :template_path     => template_dir,
         :repo_path         => topic.repo_path,
       }

--- a/lib/ascii_binder/helpers.rb
+++ b/lib/ascii_binder/helpers.rb
@@ -54,6 +54,10 @@ module AsciiBinder
       AsciiBinder::DOCS_ROOT_DIR
     end
 
+    def set_depth(user_depth)
+      AsciiBinder.const_set("DEPTH", user_depth)
+    end
+
     def set_log_level(user_log_level)
       AsciiBinder.const_set("LOG_LEVEL", log_levels[user_log_level])
     end

--- a/lib/ascii_binder/topic_entity.rb
+++ b/lib/ascii_binder/topic_entity.rb
@@ -239,12 +239,8 @@ module AsciiBinder
         end
       end
 
-      # Check the depth. For now, max depth is '2':
-      #
-      # [<group>,<subgroup>,<topic>]
-      #
-      # But this limit will be lifted in the next major version
-      if depth > 2
+      # Check the depth.
+      if (depth > AsciiBinder::DEPTH) and (AsciiBinder::DEPTH != 0)
         if verbose
           errors << "#{entity_id} exceeds the maximum nested depth."
         else

--- a/templates/_templates/_breadcrumb.html.erb
+++ b/templates/_templates/_breadcrumb.html.erb
@@ -1,0 +1,14 @@
+<%- navigation.each do |topic_group| -%>
+  <%- if topic_id.start_with?(topic_group[:id]) %>
+    <li class="hidden-xs active">
+      <%- if topic_group.has_key?(:topics) -%>
+        <a href="<%= subtopic_shim %><%= topic_group[:path] %>"><%= topic_group[:name] %></a>
+      <%- else -%>
+        <%= topic_group[:name] %>
+      <%- end -%>
+    </li>
+  <%- end -%>
+  <%- if topic_group.has_key?(:topics) -%>
+    <%= render("_templates/_breadcrumb.html.erb", :navigation => topic_group[:topics], :topic_id => topic_id, :subtopic_shim => subtopic_shim) %>
+  <%- end -%>
+<%- end -%>

--- a/templates/_templates/_nav.html.erb
+++ b/templates/_templates/_nav.html.erb
@@ -1,31 +1,14 @@
-<ul class="nav nav-sidebar">
-  <%- navigation.each.with_index do |topic_group, groupidx| -%>
-    <%- current_group = topic_group[:id] == group_id -%>
+<%- navigation.each do |topic_group| -%>
+  <%- if not topic_group.has_key?(:topics) -%>
+      <li><a class="<%= topic_id.start_with?(topic_group[:id]) ? ' active' : '' %>" href="<%= subtopic_shim %><%= topic_group[:path] %>"><%= topic_group[:name] %></a></li>
+  <%- else -%>
     <li class="nav-header">
-      <a class="" href="#" data-toggle="collapse" data-target="#topicGroup<%= groupidx %>">
-        <span id="tgSpan<%= groupidx %>" class="fa <%= current_group ? 'fa-angle-down' : 'fa-angle-right' %>"></span><%= topic_group[:name] %>
+      <a class="" href="#" data-toggle="collapse" data-target="#topicGroup-<%= topic_group[:id].hash %>">
+        <span id="sgSpan-<%= topic_group[:id].hash %>" class="fa <%= topic_id.start_with?(topic_group[:id]) ? 'fa-caret-down' : 'fa-caret-right' %>"></span>&nbsp;<%= topic_group[:name] %>
       </a>
-      <ul id="topicGroup<%= groupidx %>" class="collapse <%= current_group ? 'in' : '' %> list-unstyled">
-        <%- topic_group[:topics].each.with_index do |topic, topicidx| -%>
-          <%- if not topic.has_key?(:topics) -%>
-            <%- current_topic = current_group && (topic[:id] == topic_id) -%>
-            <li><a class="<%= current_topic ? ' active' : '' %>" href="<%= subtopic_shim %><%= topic[:path] %>"><%= topic[:name] %></a></li>
-          <%- else -%>
-            <%- current_subgroup = topic[:id] == subgroup_id -%>
-            <li class="nav-header">
-              <a class="" href="#" data-toggle="collapse" data-target="#topicSubGroup-<%= groupidx %>-<%= topicidx %>">
-                <span id="sgSpan-<%= groupidx %>-<%= topicidx %>" class="fa <%= current_subgroup ? 'fa-caret-down' : 'fa-caret-right' %>"></span>&nbsp;<%= topic[:name] %>
-              </a>
-              <ul id="topicSubGroup-<%= groupidx %>-<%= topicidx %>" class="nav-tertiary list-unstyled collapse<%= current_subgroup ? ' in' : '' %>">
-                <%- topic[:topics].each do |subtopic| -%>
-                  <%- current_subtopic = current_group && current_subgroup && (subtopic[:id] == topic_id) %>
-                  <li><a class="<%= current_subtopic ? ' active' : '' %>" href="<%= subtopic_shim %><%= subtopic[:path] %>"><%= subtopic[:name] %></a></li>
-                <%- end -%>
-              </ul>
-            </li>
-          <%- end -%>
-        <%- end -%>
-      </ul>
+    <ul id="topicGroup-<%= topic_group[:id].hash %>" class="collapse <%= topic_id.start_with?(topic_group[:id]) ? 'in' : '' %> list-unstyled">
+      <%= render("_templates/_nav.html.erb", :navigation => topic_group[:topics], :topic_id => topic_id, :subtopic_shim => subtopic_shim) %>
+    </ul>
     </li>
   <%- end -%>
-</ul>
+<%- end -%>

--- a/templates/_templates/_title.html.erb
+++ b/templates/_templates/_title.html.erb
@@ -1,0 +1,8 @@
+<%- navigation.each do |topic_group| -%>
+  <%- if topic_id.start_with?(topic_group[:id]) %>
+    | <%= topic_group[:name] %>
+  <%- end -%>
+  <%- if topic_group.has_key?(:topics) -%>
+    <%= render("_templates/_title.html.erb", :navigation => topic_group[:topics], :topic_id => topic_id) %>
+  <%- end -%>
+<%- end -%>

--- a/templates/_templates/page.html.erb
+++ b/templates/_templates/page.html.erb
@@ -4,7 +4,9 @@
   <meta charset="utf-8">
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
-  <title><%= distro %> <%= version %> | <%= [group_title, subgroup_title, topic_title].compact.join(' | ') %></title>
+  <title><%= distro %> <%= version %>
+      <%= render("_templates/_title.html.erb", :navigation => navigation, :topic_id => topic_id) %>
+  </title>
 
   <!-- Bootstrap -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
@@ -39,20 +41,13 @@
       <li class="sitename">
         <a href="<%= site_home_path %>"><%= site_name %></a>
       </li>
-      <li class="hidden-xs active">
-        <%= breadcrumb_root %>
-      </li>
-      <li class="hidden-xs active">
-        <%= breadcrumb_group %>
-      </li>
-      <%= breadcrumb_subgroup_block %>
-      <li class="hidden-xs active">
-        <%= breadcrumb_topic %>
-      </li>
+      <%= render("_templates/_breadcrumb.html.erb", :navigation => navigation, :topic_id => topic_id, :subtopic_shim => subtopic_shim) %>
     </ol>
     <div class="row row-offcanvas row-offcanvas-left">
       <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas">
-        <%= render("_templates/_nav.html.erb", :navigation => navigation, :group_id => group_id, :topic_id => topic_id, :subgroup_id => subgroup_id, :subtopic_shim => subtopic_shim) %>
+        <ul class="nav nav-sidebar">
+          <%= render("_templates/_nav.html.erb", :navigation => navigation, :topic_id => topic_id, :subtopic_shim => subtopic_shim) %>
+        </ul>
       </div>
       <div class="col-xs-12 col-sm-9 col-md-9 main">
         <div class="page-header">


### PR DESCRIPTION
Create a new set of templates that supports unlimited depth
navigation trees through recursive templates and the
navigation object

Preserve all legacy functionality by retaining id markers,
breadcrumbing, etc.