### PR TITLE
Add generic vars support

### DIFF
--- a/lib/ascii_binder/distro.rb
+++ b/lib/ascii_binder/distro.rb
@@ -7,13 +7,14 @@ include AsciiBinder::Helpers
 
 module AsciiBinder
   class Distro
-    attr_reader :id, :name, :author, :site
+    attr_reader :id, :name, :author, :site, :vars
 
     def initialize(distro_map_filepath,distro_key,distro_config)
       @id         = distro_key
       @name       = distro_config['name']
       @author     = distro_config['author']
       @site       = AsciiBinder::Site.new(distro_config)
+      @vars        = distro_config['vars']
       @branch_map = {}
       distro_config['branches'].each do |branch_name,branch_config|
         if @branch_map.has_key?(branch_name)

--- a/lib/ascii_binder/distro_branch.rb
+++ b/lib/ascii_binder/distro_branch.rb
@@ -4,7 +4,7 @@ include AsciiBinder::Helpers
 
 module AsciiBinder
   class DistroBranch
-    attr_reader :id, :name, :dir, :distro, :distro_name, :distro_author
+    attr_reader :id, :name, :dir, :distro, :distro_name, :distro_author, :vars
 
     def initialize(branch_name,branch_config,distro)
       @id            = branch_name
@@ -13,6 +13,7 @@ module AsciiBinder
       @distro        = distro
       @distro_name   = distro.name
       @distro_author = distro.author
+      @vars          = branch_config['vars']
       if branch_config.has_key?('distro-overrides')
         if branch_config['distro-overrides'].has_key?('name')
           @distro_name = branch_config['distro-overrides']['name']

--- a/lib/ascii_binder/engine.rb
+++ b/lib/ascii_binder/engine.rb
@@ -491,6 +491,22 @@ module AsciiBinder
       preview_path = topic.preview_path(distro.id,branch_config.dir)
       topic_publish_url = topic.topic_publish_url(distro.site.url,branch_config.dir)
 
+      # Collect the topic keys together.  Allow lower level overriding
+      el = topic
+      topic_vars = {}
+      while el != nil do
+        if el.vars != nil
+          el.vars.each do |varhash|
+            if topic_vars == {}
+              topic_vars = varhash
+            else
+              topic_vars.merge(varhash) {|key, oldval, newval| oldval}
+            end
+          end
+        end
+        el = el.parent
+      end
+
       page_args = {
         :distro_key        => distro.id,
         :distro            => branch_config.distro_name,
@@ -514,6 +530,9 @@ module AsciiBinder
         :site_home_path    => "../../#{dir_depth}index.html",
         :template_path     => template_dir,
         :repo_path         => topic.repo_path,
+        :distro_vars       => distro.vars,
+        :branch_vars       => branch_config.vars,
+        :topic_vars        => topic_vars,
       }
       full_file_text = page(page_args)
       File.write(preview_path,full_file_text)

--- a/lib/ascii_binder/topic_entity.rb
+++ b/lib/ascii_binder/topic_entity.rb
@@ -5,7 +5,7 @@ include AsciiBinder::Helpers
 
 module AsciiBinder
   class TopicEntity
-    attr_reader :name, :dir, :file, :topic_alias, :distro_keys, :subitems, :raw, :parent, :depth
+    attr_reader :name, :dir, :file, :topic_alias, :distro_keys, :subitems, :raw, :parent, :depth, :vars
 
     def initialize(topic_entity,actual_distro_keys,dir_path='',parent_group=nil,depth=0)
       @raw                = topic_entity
@@ -15,6 +15,7 @@ module AsciiBinder
       @dir                = topic_entity['Dir']
       @file               = topic_entity['File']
       @topic_alias        = topic_entity['Alias']
+      @vars               = topic_entity['vars']
       @depth              = depth
       @actual_distro_keys = actual_distro_keys
       @distro_keys        = topic_entity.has_key?('Distros') ? parse_distros(topic_entity['Distros']) : actual_distro_keys


### PR DESCRIPTION
vars can now be specific in the _distro_map.yml to pass in
arbitrary distro or branch specific values to the template
processor.  They show up in the distro_vars and branch_vars
variables.  The name is lower case to match the others in
_distro_map.yml

Vars can be specified (upper case because other values are
upper case in _topic_map.yml) can be specified for both Dir
and File entries.  They show up in the template in the variable
topic_vars.  The vars are consolidated so you get all variables
from the top to what ever topic you are processing.  Lower level
vars override those from the top.