### PR TITLE
Update dockerfile to allow user to create output files not owned by root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN scl enable rh-ruby22 -- gem install ascii_binder
 USER root
 RUN yum install -y java-1.7.0-openjdk && \
     yum clean all
-
+USER nobody
 LABEL url="http://www.asciibinder.org" \
       summary="a documentation system built on Asciidoctor" \
       description="AsciiBinder is for documenting versioned, interrelated projects. Run this container image from the documentation repository, which is mounted into the container. Note: Generated files will be owned by root." \


### PR DESCRIPTION
The exister dockerfile creates output as root. This makes life difficult for ordinary users who run this this docker file to create html. 
However, my proposal isn't ideal, it means that the user must allow nobody write access to the docs repo before running the container. 
I'm happy to chmod a+rwx <repo> before running the container, but maybe others wouldn't want to do that.