### PR TITLE
Make rake a development dependency.

### DIFF
--- a/ascii_binder.gemspec
+++ b/ascii_binder.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "cucumber", "~> 2.3.3"
   spec.add_development_dependency "diff_dirs", "~> 0.1.2"
-  spec.add_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 10.0"
 
   spec.add_dependency 'asciidoctor', '~> 1.5.6'
   spec.add_dependency 'asciidoctor-diagram', '~> 1.5.5'


### PR DESCRIPTION
While playing around with rake I don't think it should be a runtime dependency. The only way how to use it is through the following call:
~~~
$ rake -f /usr/share/gems/gems/ascii_binder-0.1.14/lib/ascii_binder/tasks/tasks.rb build
~~~
Attached patch is removing rake from runtime dependencies. Feedback is appreciated.