### PR TITLE
Upgrade SitemapGenerator dependency to pull in a fix

### DIFF
--- a/ascii_binder.gemspec
+++ b/ascii_binder.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'guard-livereload'
   spec.add_dependency 'haml'
   spec.add_dependency 'json'
-  spec.add_dependency 'sitemap_generator', '~> 5.1.0'
+  spec.add_dependency 'sitemap_generator', '~> 6.0.1'
   spec.add_dependency 'trollop', '~> 2.1.2'
   spec.add_dependency 'yajl-ruby', '~> 1.3.0'
   spec.add_dependency 'tilt'

--- a/lib/ascii_binder/version.rb
+++ b/lib/ascii_binder/version.rb
@@ -1,3 +1,3 @@
 module AsciiBinder
-  VERSION = "0.1.15"
+  VERSION = "0.1.15.1"
 end


### PR DESCRIPTION
BigDecimal has evolved a bit and this was causing a problem within the 5.1.0 version of SitemapGenerator. I've updated the AsciiBinder to pull in the 6.0.1 version which has been updated to work with more recent versions of BigDecimal.