### PR TITLE
Changed default depth to 3

### DIFF
--- a/bin/asciibinder
+++ b/bin/asciibinder
@@ -133,7 +133,7 @@ EOF
       opt :distro, "Instead of building all distros, build branches only for the specified distro.", :default => ''
       opt :page, "Build only the specified page for all distros and only the current working branch.", :default => ''
       opt :log_level, "Set the logging output level for this operation.", :default => 'warn'
-      opt :toc_depth, "Maximum depth of topics allowed.  Use 0 for infinite depth.", :default => 2
+      opt :toc_depth, "Maximum depth of topics allowed.  Use 0 for infinite depth.", :default => 3
       conflicts :distro, :page
     end
   when "create"
@@ -208,7 +208,7 @@ Options:
 EOF
       opt :site, "Instead of packaging every docs site, package the specified site only.", :default => ''
       opt :log_level, "Set the logging output level for this operation.", :default => 'warn'
-      opt :toc_depth, "Maximum depth of topics allowed.  Use 0 for infinite depth.", :default => 2
+      opt :toc_depth, "Maximum depth of topics allowed.  Use 0 for infinite depth.", :default => 3
     end
   when "help"
     Trollop::educate
@@ -277,7 +277,7 @@ end
 set_log_level(user_log_level)
 
 # Set the depth level
-user_depth = 2
+user_depth = 3
 unless cmd_opts.nil? or cmd_opts[:toc_depth].nil?
   user_depth = cmd_opts[:toc_depth].to_i
 end

--- a/lib/ascii_binder/version.rb
+++ b/lib/ascii_binder/version.rb
@@ -1,3 +1,3 @@
 module AsciiBinder
-  VERSION = "0.1.15.1"
+  VERSION = "0.1.15.2"
 end


### PR DESCRIPTION
Hey @nhr - not sure if you are still looking at this but I have changed the default depth to 3 instead of 2 due to the many products building on top of OpenShift and the need to be able to define navigation for them at a deeper level.

All this PR does is make it the default instead of 2.

I know that:
1. I can set the toc_depth=3 instead of making 3 the default. But that would require everyone who builds with asciibinder to set that at the command line, which is a bit of a pain.

2. The OpenShift docs will need to change their navigation template to support a depth of 3. I have a PR in progress for this.

If you have no objections to it, I will merge it later tomorrow and then publish the gem.