### PR TITLE
Use rouge syntax highlighter

### DIFF
--- a/ascii_binder.gemspec
+++ b/ascii_binder.gemspec
@@ -18,13 +18,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "cucumber", "~> 2.3.3"
   spec.add_development_dependency "diff_dirs", "~> 0.1.2"
   spec.add_dependency "rake", "~> 12.3.3"
 
-  spec.add_dependency 'asciidoctor', '~> 1.5.6'
-  spec.add_dependency 'asciidoctor-diagram', '~> 1.5.5'
+  spec.add_dependency 'asciidoctor', '~> 2.0.10'
+  spec.add_dependency 'asciidoctor-diagram', '~> 2.0.2'
+  spec.add_dependency 'rouge', '~> 3.18.0'
   spec.add_dependency 'git'
   spec.add_dependency 'guard'
   spec.add_dependency 'guard-shell'

--- a/lib/ascii_binder/engine.rb
+++ b/lib/ascii_binder/engine.rb
@@ -238,8 +238,7 @@ module AsciiBinder
 
     def asciidoctor_page_attrs(more_attrs=[])
       [
-        'source-highlighter=coderay',
-        'coderay-css=style',
+        'source-highlighter=rouge',
         'linkcss!',
         'icons=font',
         'idprefix=',


### PR DESCRIPTION
This PR changes the highlighter to rogue, a Ruby based syntax
highlighter. It requires asciidoctor 2.0.0 or newer, however.

cc @vikram-redhat 