### PR TITLE
Rm --help mention of LiveReload browser plugins

### DIFF
--- a/bin/asciibinder
+++ b/bin/asciibinder
@@ -183,11 +183,9 @@ Description:
   ...except that the Guardfile automatically detects and runs this as
   you work.
 
-  This is meant to be used in conjunction with a web browser that is
-  running a LiveReload plugin. If you are viewing the output HTML page
-  in a browser where LiveReload is active, then every time you save a
-  new version of the .adoc file, the new HTML is automatically
-  regenerated and your page view is automatically refreshed.
+  This is meant to be used in conjunction with a web browser that is viewing the
+  output HTML page. Every time you save a new version of the .adoc file, you can
+  manually refresh your page to view the newly-generated HTML.
 EOF
       opt :log_level, "Set the logging output level for this operation.", :default => 'warn'
     end


### PR DESCRIPTION
The LiveReload extension from the Chrome Web Store requires too much permission, and the original Firefox add-on is no longer available (seems like random replacements have taken its place), so it doesn't seem worth recommending seeking one out anymore. The basic `asciibinder watch` behavior of automatically rebuilding a page does still work fine, however, so it's still helpful even with a manual browser refresh.

Update the `--help` output to no longer mention the browser plugin.

cc @vikram-redhat 