### PR TITLE
Fix tests master to main

### DIFF
--- a/ascii_binder.gemspec
+++ b/ascii_binder.gemspec
@@ -36,5 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'trollop', '~> 2.1.2'
   spec.add_dependency 'yajl-ruby', '~> 1.3.0'
   spec.add_dependency 'tilt'
+  spec.add_dependency 'bigdecimal'
 
 end

--- a/features/support/_clone_distro_map.yml
+++ b/features/support/_clone_distro_map.yml
@@ -6,7 +6,7 @@ ascii_binder:
   site_name: Home
   site_url: http://asciibinder.org/
   branches:
-    master:
+    main:
       name: Latest
       dir: latest
     branch1:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -364,7 +364,7 @@ module Helpers
 
     # Make sure the build finished on the same branch where it started.
     git = Git.open(working_dir)
-    current_working_branch = git.branch.name
+    current_working_branch = git.current_branch
     unless current_working_branch == initial_working_branch
       puts "ERROR: Build operation started on branch '#{initial_working_branch}' but ended on branch '#{current_working_branch}'"
       exit 1

--- a/features/support/test_distro/_distro_map.yml
+++ b/features/support/test_distro/_distro_map.yml
@@ -6,7 +6,7 @@ distro_main:
   site_name: Home
   site_url: http://asciibinder.org/
   branches:
-    master:
+    main:
       name: Latest
       dir: latest
     branch1:
@@ -19,11 +19,11 @@ distro_test:
   site_name: TEST_SITE
   site_url: http://docs.test.example.com/
   branches:
-    master:
+    main:
       name: TEST_BRANCH_LATEST
       dir: test_latest
       distro-overrides:
         name: TEST_BRANCH_NICEST
     branch2:
       name: TEST_BRANCH_2
-      dir: 'test_branch/2'
+      dir: "test_branch/2"

--- a/templates/_distro_map.yml
+++ b/templates/_distro_map.yml
@@ -6,6 +6,6 @@ ascii_binder:
   site_name: Home
   site_url: http://asciibinder.org/
   branches:
-    master:
+    main:
       name: Latest
       dir: latest


### PR DESCRIPTION
I wasn't able to run the tests without errors and had to add `bigdecimal` as a dependency and change the way that the Git module determined the current branch.  If these are user error, please let me know.

For the dependency, this is the error that I otherwise face:

```text
Scenario: A user wants to do a build in a repo with alias that points to a nonexistent topic # features/repo_build.featur
e:16                                                                                                                      
    Given a valid AsciiBinder docs repo with an invalid alias                                  # features/step_definitions/
steps.rb:15                                                                                                               
      ERROR: Could not initialize test repo.                                                                               
      STDOUT:          
      STDERR:                                                                                                              
      /project/vendor/bundle/ruby/2.7.0/gems/asciidoctor-diagram-2.0.5/lib/asciidoctor-diagram/util/svg.rb:3:in `require': 
cannot load such file -- bigdecimal (LoadError)                                                      
```

For the Git issue, this is the error message that I receive:

```text Scenario: A user wants to build all distros against the current repo branch        # features/repo_build.feature:11     
    Given a valid AsciiBinder docs repo with multiple distros                        # features/step_definitions/steps.rb:1
5   
    When the user runs `asciibinder build` on that repo directory                    # features/step_definitions/steps.rb:7
9                      
    Then the program generates preview content for all distros in the current branch # features/step_definitions/steps.rb:1
58                                                  
      ERROR: Build operation started on branch 'main' but ended on branch 'master'                                        
      exit (SystemExit)                                                            
```
