### PR TITLE
update ruby version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM centos/ruby-22-centos7
+FROM centos/ruby-23-centos7
 
-RUN scl enable rh-ruby22 -- gem install listen -v 3.0.8
-RUN scl enable rh-ruby22 -- gem install ascii_binder
+RUN scl enable rh-ruby23 -- gem install listen -v 3.0.8
+RUN scl enable rh-ruby23 -- gem install ascii_binder
 USER root
 RUN yum install -y java-1.7.0-openjdk && \
     yum clean all


### PR DESCRIPTION
The ruby 2.2 image was causing issues with building asciibinder, namely one of the dependencies required a newer version of ffi. This change updates the ruby version and the commands to enable ruby.