### PR TITLE
update whitespace to hyphen

### DIFF
--- a/lib/ascii_binder/engine.rb
+++ b/lib/ascii_binder/engine.rb
@@ -412,7 +412,7 @@ module AsciiBinder
           end
 
           # Get the current distro / branch object
-          branch_config = AsciiBinder::DistroBranch.new('',{ "name" => "Branch Build", "dir" => local_branch },distro)
+          branch_config = AsciiBinder::DistroBranch.new('',{ "name" => "Branch-Build", "dir" => local_branch },distro)
           dev_branch    = true
           if distro.branch_ids.include?(local_branch)
             branch_config = distro.branch(local_branch)


### PR DESCRIPTION
From [this conversation on Slack](https://redhat-internal.slack.com/archives/C02KBD8A4UF/p1681336263348639), it might make sense to update the `branch_config.name` to remove the whitespace in "Branch Build"

Currently, trying to use the attribute `{product-version}` within a `link` macro generates a broken output because of the whitespace in "Branch Build": after substitution asciibinder only sees `link:https://example.com/Branch`, cutting off the at the whitespace, which is not a valid link since it is missing the `[]` at the end